### PR TITLE
Join greenlet in parallel thread

### DIFF
--- a/asyncio_gevent/greenlet_to_future.py
+++ b/asyncio_gevent/greenlet_to_future.py
@@ -44,7 +44,13 @@ async def _await_greenlet(
         greenlet.join()
 
     try:
-        return await future
+        loop = asyncio.get_running_loop()
+
+        result, _ = await asyncio.gather(
+            future, loop.run_in_executor(None, greenlet.join)
+        )
+
+        return result
     except asyncio.CancelledError:
         if autokill_greenlet:
             greenlet.kill()

--- a/asyncio_gevent/greenlet_to_future.py
+++ b/asyncio_gevent/greenlet_to_future.py
@@ -41,8 +41,6 @@ async def _await_greenlet(
 
         greenlet.link(cb)
 
-        greenlet.join()
-
     try:
         loop = asyncio.get_running_loop()
 


### PR DESCRIPTION
Fixes #8. This PR changes the behaviour of `asyncio.greenlet_to_future` by making sure that the greenlet is awaited in a separate thread which prevents blocking of the main thread and makes interrupts safe to use with the code. The PR also adds a note to the README describing how to work with `gevent.sleep`.