### PR TITLE
Update max version of gevent

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ python = "^3.7"
 gevent = [
     {version = "*", python = ">=3.7, <3.10"},
     {version = "^21.12.0", python = ">=3.10, <3.11"},
-    {version = "^24.2.1", python = "^3.11"}
+    {version = ">=22.10.2", python = "^3.11"}
 ]
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
The max version of gevent is fairly out of date with what is available and all actions seem to work with the latest version (24.2.1) as well as all included unit tests pass.

## Summary by Sourcery

Enhancements:
- Update gevent version constraint for Python 3.11 from ^22.10.2 to ^24.2.1 in pyproject.toml